### PR TITLE
SDTReader: whitespace adjustments in the docs

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/SDTReader.java
+++ b/components/formats-gpl/src/loci/formats/in/SDTReader.java
@@ -47,8 +47,8 @@ import loci.formats.meta.MetadataStore;
  *
  * Please Note: This format holds FLIM data arranged so that each decay is stored contiguously.
  * Therefore, as in other FLIM format readers e.g. SDTReader.java, on the first call to openBytes
- * the whole data cube ( x,y,t) (NB actually t not real-time T) is loaded from the file and buffered
- * On further calls to openBytes the appropriate 2D (x,y)plane (timebin) is returned from this buffer.
+ * the whole data cube (x, y, t) (NB actually t, not real-time T) is loaded from the file and buffered.
+ * On further calls to openBytes the appropriate 2D (x, y) plane (timebin) is returned from this buffer.
  * This is in the interest of significantly improved  performance when all the planes are requested one after another.
  * There will be a performance cost if a single plane is requested but this is highly unlikely for FLIM data.
  * In order to limit the size of the buffer, beyond a certain size threshold only a subset of planes (a Block) are


### PR DESCRIPTION
Minor whitespace fixes in the initial doc section.
